### PR TITLE
Add GitHub Actions workflow for TestPyPI pre-releases

### DIFF
--- a/.github/workflows/publish-to-testpypi.yml
+++ b/.github/workflows/publish-to-testpypi.yml
@@ -1,0 +1,37 @@
+name: Publish Python 🐍 distributions 📦 to TestPyPI
+
+on:
+  release:
+    types: [prereleased]
+
+jobs:
+  build-and-publish:
+    name: Build and publish Python 🐍 distributions 📦 to TestPyPI
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+
+    - name: Install build dependencies
+      run: python -m pip install build
+
+    - name: Build package
+      run: python -m build
+
+    - name: Publish package to TestPyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        # You will need to create a TestPyPI API token and add it to your
+        # GitHub repository secrets with the name TEST_PYPI_API_TOKEN
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/


### PR DESCRIPTION
Introduce a workflow to publish pre-releases to TestPyPI, enabling testing of the package distribution process before final release. This workflow triggers on the creation of a `prereleased` release and uses a dedicated API token for authentication.