### PR TITLE
Prevent PyPI publish on pre-releases

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -8,7 +8,7 @@ jobs:
   build-and-publish:
     name: Build and publish Python 🐍 distributions 📦 to PyPI
     runs-on: ubuntu-latest
-
+    if: ${{ !github.event.release.prerelease }}
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
Add a condition to the PyPI publishing workflow to ensure it only triggers on stable releases, preventing conflicts with the TestPyPI workflow.