### PR TITLE
Add tests for chat exporter, markdown, and mention parsing

### DIFF
--- a/tests/test_chat_exporter.py
+++ b/tests/test_chat_exporter.py
@@ -1,0 +1,58 @@
+import pytest
+from unittest.mock import MagicMock, AsyncMock, patch
+import DiscordTranscript.chat_exporter as chat_exporter
+
+@pytest.fixture
+def mock_channel():
+    channel = AsyncMock()
+    channel.name = "test-channel"
+    channel.guild = MagicMock()
+    return channel
+
+@pytest.fixture
+def mock_bot():
+    return MagicMock()
+
+@pytest.fixture
+def mock_transcript():
+    transcript = MagicMock()
+    transcript.html = "<html><body>Test Transcript</body></html>"
+    return transcript
+
+@pytest.mark.asyncio
+@patch("DiscordTranscript.chat_exporter.Transcript")
+async def test_quick_export(MockTranscript, mock_channel, mock_bot, mock_transcript):
+    mock_transcript_instance = mock_transcript
+    mock_transcript_instance.export = AsyncMock(return_value=mock_transcript_instance)
+    MockTranscript.return_value = mock_transcript_instance
+
+    await chat_exporter.quick_export(mock_channel, bot=mock_bot)
+
+    MockTranscript.assert_called_once()
+    mock_channel.send.assert_called_once()
+
+
+@pytest.mark.asyncio
+@patch("DiscordTranscript.chat_exporter.Transcript")
+async def test_export(MockTranscript, mock_channel, mock_bot, mock_transcript):
+    mock_transcript_instance = mock_transcript
+    mock_transcript_instance.export = AsyncMock(return_value=mock_transcript_instance)
+    MockTranscript.return_value = mock_transcript_instance
+
+    html = await chat_exporter.export(mock_channel, bot=mock_bot)
+
+    MockTranscript.assert_called_once()
+    assert html == mock_transcript.html
+
+@pytest.mark.asyncio
+@patch("DiscordTranscript.chat_exporter.Transcript")
+async def test_raw_export(MockTranscript, mock_channel, mock_bot, mock_transcript):
+    mock_transcript_instance = mock_transcript
+    mock_transcript_instance.export = AsyncMock(return_value=mock_transcript_instance)
+    MockTranscript.return_value = mock_transcript_instance
+    messages = [MagicMock()]
+
+    html = await chat_exporter.raw_export(mock_channel, messages=messages, bot=mock_bot)
+
+    MockTranscript.assert_called_once()
+    assert html == mock_transcript.html

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -1,0 +1,98 @@
+import pytest
+from DiscordTranscript.parse.markdown import ParseMarkdown
+
+@pytest.mark.asyncio
+async def test_bold_markdown():
+    parser = ParseMarkdown("**hello world**")
+    await parser.standard_message_flow()
+    assert parser.content.strip() == "<strong>hello world</strong>"
+
+@pytest.mark.asyncio
+async def test_underline_markdown():
+    parser = ParseMarkdown("__hello world__")
+    await parser.standard_message_flow()
+    assert parser.content.strip() == '<span style="text-decoration: underline">hello world</span>'
+
+@pytest.mark.asyncio
+async def test_italic_markdown():
+    parser = ParseMarkdown("*hello world*")
+    await parser.standard_message_flow()
+    assert parser.content.strip() == "<em><span>hello world</span></em>"
+
+@pytest.mark.asyncio
+async def test_italic_underscore_markdown():
+    parser = ParseMarkdown("_hello world_")
+    await parser.standard_message_flow()
+    assert parser.content.strip() == "<em><span>hello world</span></em>"
+
+@pytest.mark.asyncio
+async def test_strike_through_markdown():
+    parser = ParseMarkdown("~~hello world~~")
+    await parser.standard_message_flow()
+    assert parser.content.strip() == '<span style="text-decoration: line-through">hello world</span>'
+
+@pytest.mark.asyncio
+async def test_h1_markdown():
+    parser = ParseMarkdown("# hello world")
+    await parser.standard_message_flow()
+    assert parser.content.strip() == "<h1>hello world</h1>"
+
+@pytest.mark.asyncio
+async def test_h2_markdown():
+    parser = ParseMarkdown("## hello world")
+    await parser.standard_message_flow()
+    assert parser.content.strip() == "<h2>hello world</h2>"
+
+@pytest.mark.asyncio
+async def test_h3_markdown():
+    parser = ParseMarkdown("### hello world")
+    await parser.standard_message_flow()
+    assert parser.content.strip() == "<h3>hello world</h3>"
+
+@pytest.mark.asyncio
+async def test_spoiler_markdown():
+    parser = ParseMarkdown("||hello world||")
+    await parser.standard_message_flow()
+    assert parser.content.strip() == '<span class="spoiler spoiler--hidden" onclick="showSpoiler(event, this)"> <span class="spoiler-text">hello world</span></span>'
+
+@pytest.mark.asyncio
+async def test_quote_markdown():
+    parser = ParseMarkdown("&gt; hello world")
+    await parser.standard_message_flow()
+    assert parser.content.strip() == '<div class="quote">hello world</div>'
+
+@pytest.mark.asyncio
+async def test_code_block_markdown():
+    parser = ParseMarkdown("`hello world`")
+    await parser.standard_message_flow()
+    assert "hello world" in parser.content
+
+@pytest.mark.asyncio
+async def test_multiline_code_block_markdown():
+    parser = ParseMarkdown("```\nhello world\n```")
+    await parser.standard_message_flow()
+    assert "hello world" in parser.content
+
+@pytest.mark.asyncio
+async def test_link_markdown():
+    parser = ParseMarkdown("[google](https://google.com)")
+    parser.parse_embed_markdown()
+    assert parser.content == '<a href="https://google.com">google</a>'
+
+@pytest.mark.asyncio
+async def test_https_link():
+    parser = ParseMarkdown("https://google.com")
+    await parser.standard_message_flow()
+    assert parser.content.strip() == '<a href="https://google.com">https://google.com</a>'
+
+@pytest.mark.asyncio
+async def test_emoji():
+    parser = ParseMarkdown(":joy:")
+    await parser.special_emoji_flow()
+    assert ":joy:" in parser.content
+
+@pytest.mark.asyncio
+async def test_custom_emoji():
+    parser = ParseMarkdown("<:custom:12345>")
+    await parser.parse_emoji()
+    assert '<img class="emoji emoji--small" src="https://cdn.discordapp.com/emojis/12345.png">' in parser.content

--- a/tests/test_mention.py
+++ b/tests/test_mention.py
@@ -1,0 +1,131 @@
+import pytest
+from unittest.mock import MagicMock, AsyncMock
+
+from DiscordTranscript.parse.mention import ParseMention, pass_bot
+
+
+@pytest.fixture
+def mock_guild():
+    guild = MagicMock()
+    guild.id = 12345
+    guild.name = "Test Guild"
+    return guild
+
+
+@pytest.fixture
+def mock_bot():
+    bot = MagicMock()
+    return bot
+
+
+@pytest.mark.asyncio
+async def test_channel_mention(mock_guild):
+    channel = MagicMock()
+    channel.id = 54321
+    channel.name = "test-channel"
+    mock_guild.get_channel.return_value = channel
+
+    parser = ParseMention("<#54321>", mock_guild)
+    await parser.channel_mention()
+    assert parser.content == '<span class="mention" title="54321">#test-channel</span>'
+
+    parser = ParseMention("&lt;#54321&gt;", mock_guild)
+    await parser.channel_mention()
+    assert parser.content == '<span class="mention" title="54321">#test-channel</span>'
+
+    mock_guild.get_channel.return_value = None
+    parser = ParseMention("<#12345>", mock_guild)
+    await parser.channel_mention()
+    assert parser.content == '#deleted-channel'
+
+
+@pytest.mark.asyncio
+async def test_role_mention(mock_guild):
+    role = MagicMock()
+    role.id = 98765
+    role.name = "Test Role"
+    role.color = MagicMock()
+    role.color.r = 255
+    role.color.g = 0
+    role.color.b = 0
+    mock_guild.get_role.return_value = role
+
+    parser = ParseMention("<@&98765>", mock_guild)
+    await parser.role_mention()
+    assert parser.content == '<span style="color: #ff0000;">@Test Role</span>'
+
+    parser = ParseMention("&lt;@&amp;98765&gt;", mock_guild)
+    await parser.role_mention()
+    assert parser.content == '<span style="color: #ff0000;">@Test Role</span>'
+
+    mock_guild.get_role.return_value = None
+    parser = ParseMention("<@&12345>", mock_guild)
+    await parser.role_mention()
+    assert parser.content == '@deleted-role'
+
+
+@pytest.mark.asyncio
+async def test_member_mention(mock_guild, mock_bot):
+    pass_bot(mock_bot)
+    member = MagicMock()
+    member.id = 112233
+    member.display_name = "TestUser"
+    mock_guild.get_member.return_value = member
+    mock_bot.get_user.return_value = None
+
+    parser = ParseMention("<@112233>", mock_guild)
+    await parser.member_mention()
+    assert parser.content == '<span class="mention" title="112233">@TestUser</span>'
+
+    parser = ParseMention("&lt;@112233&gt;", mock_guild)
+    await parser.member_mention()
+    assert parser.content == '<span class="mention" title="112233">@TestUser</span>'
+
+    mock_guild.get_member.return_value = None
+    parser = ParseMention("<@445566>", mock_guild)
+    await parser.member_mention()
+    assert parser.content == '<span class="mention" title="445566">&lt;@445566></span>'
+
+
+@pytest.mark.asyncio
+async def test_time_mention(mock_guild):
+    mock_guild.timezone = "UTC"
+    parser = ParseMention("&lt;t:1622548800:f&gt;", mock_guild)
+    await parser.time_mention()
+    assert 'June 2021 11:59' in parser.content
+
+@pytest.mark.asyncio
+async def test_slash_command_mention(mock_guild):
+    parser = ParseMention("&lt;/test command:123456789&gt;", mock_guild)
+    await parser.slash_command_mention()
+    assert parser.content == '<span class="mention" title="test command">/test command</span>'
+
+@pytest.mark.asyncio
+async def test_flow(mock_guild):
+    mock_guild.timezone = "UTC"
+    channel = MagicMock()
+    channel.id = 54321
+    channel.name = "test-channel"
+    mock_guild.get_channel.return_value = channel
+
+    role = MagicMock()
+    role.id = 98765
+    role.name = "Test Role"
+    role.color = MagicMock()
+    role.color.r = 255
+    role.color.g = 0
+    role.color.b = 0
+    mock_guild.get_role.return_value = role
+
+    member = MagicMock()
+    member.id = 112233
+    member.display_name = "TestUser"
+    mock_guild.get_member.return_value = member
+
+    content = "Hello <@112233>, welcome to <#54321>. Please read the rules and get the <@&98765> role."
+    parser = ParseMention(content, mock_guild)
+    result = await parser.flow()
+
+    assert '<span class="mention" title="112233">@TestUser</span>' in result
+    assert '<span class="mention" title="54321">#test-channel</span>' in result
+    assert '<span style="color: #ff0000;">@Test Role</span>' in result


### PR DESCRIPTION
Introduce unit tests for the chat exporter functionality, markdown parsing, and mention parsing to ensure proper behavior and reliability of these components. These tests cover various scenarios and edge cases for each feature.