### PR TITLE
Fix: Use div for message content to improve line breaks

### DIFF
--- a/DiscordTranscript/html/message/content.html
+++ b/DiscordTranscript/html/message/content.html
@@ -1,2 +1,1 @@
-<span class="chatlog__markdown-preserve">{{MESSAGE_CONTENT}}</span>
-{{EDIT}}
+<div class="chatlog__markdown-preserve">{{MESSAGE_CONTENT}} {{EDIT}}</div>

--- a/DiscordTranscript/parse/markdown.py
+++ b/DiscordTranscript/parse/markdown.py
@@ -174,7 +174,7 @@ class ParseMarkdown:
 
     def strip_preserve(self):
         """Strips the preserve tags from the content."""
-        p = r'<span class="chatlog__markdown-preserve">(.*)</span>'
+        p = r'<div class="chatlog__markdown-preserve">(.*)</div>'
         r = "%s"
 
         pattern = re.compile(p)


### PR DESCRIPTION
- Changed message content wrapper from `span` to `div` in `content.html` to allow valid block-level element nesting (like code blocks).
- Moved `{{EDIT}}` timestamp inside the wrapper `div` to preserve inline rendering behavior.
- Updated `strip_preserve` regex in `markdown.py` to match the new `div` tag structure.
- This ensures `white-space: pre-wrap` works consistently across the entire message content.

Co-authored-by: Xougui <143881479+Xougui@users.noreply.github.com>