### PR TITLE
feat(html): add version to footer and tooltip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -226,3 +226,4 @@ DiscordTranscript/_version.py
 node_modules/
 package-lock.json
 .agents/
+uv.lock

--- a/DiscordTranscript/construct/transcript.py
+++ b/DiscordTranscript/construct/transcript.py
@@ -21,6 +21,13 @@ from DiscordTranscript.ext.html_generator import (
     meta_data_temp,
     total,
 )
+
+try:
+    from importlib.metadata import version
+
+    __version__ = version("DiscordTranscript")
+except Exception:
+    __version__ = "0.0.0-dev"
 from DiscordTranscript.i18n import TRANSLATIONS
 
 if TYPE_CHECKING:
@@ -306,6 +313,11 @@ class TranscriptDAO:
                     PARSE_MODE_NONE,
                 ),
                 ("POWERED_BY", translations["POWERED_BY"], PARSE_MODE_NONE),
+                (
+                    "VERSION",
+                    translations["GENERATED_WITH"].format(version=__version__),
+                    PARSE_MODE_NONE,
+                ),
             ],
             bot=self.bot,
             timezone=self.pytz_timezone,

--- a/DiscordTranscript/html/base.html
+++ b/DiscordTranscript/html/base.html
@@ -1120,7 +1120,6 @@
             padding: 4px 8px;
             border-radius: 4px;
             margin-left: auto;
-            margin-right: 16px;
             color: #949ba4;
             transition: background-color 0.2s ease, color 0.2s ease;
         }
@@ -1135,11 +1134,6 @@
             margin-right: 6px;
             width: 20px;
             height: 20px;
-        }
-
-        .panel__logo {
-            width: 24px;
-            height: 24px;
         }
 
         .summary-popout.visible {
@@ -1945,11 +1939,6 @@
             </svg>
             <span>{{SUMMARY}}</span>
         </div>
-
-        <a href="https://discord-transcript.xouxou-hosting.fr/index" target="_blank" rel="noopener">
-            <img class="panel__logo" src="https://discord-transcript.xouxou-hosting.fr/assets/img/clair/logo.svg"
-                alt="DiscordTranscript" />
-        </a>
     </div>
 
     <div class="main">
@@ -1969,7 +1958,7 @@
 
     <div class="footer">
         <span class="footer__text">{{GENERATED_ON}} {{DATE_TIME}}</span>
-        <div class="footer__powered">
+        <div class="footer__powered" data-version="{{VERSION}}">
             <span>{{POWERED_BY}}</span>
             <a href="https://discord-transcript.xouxou-hosting.fr/index" class="footer__powered-link" target="_blank"
                 rel="noopener">
@@ -2203,6 +2192,14 @@
                 placement: 'top',
                 animation: 'fade',
                 content: (reference) => reference.getAttribute('data-timestamp'),
+                theme: 'disc',
+            });
+
+            // Version: Tooltip
+            tippy('.footer__powered', {
+                placement: 'top',
+                animation: 'fade',
+                content: (reference) => reference.getAttribute('data-version'),
                 theme: 'disc',
             });
 

--- a/DiscordTranscript/i18n.py
+++ b/DiscordTranscript/i18n.py
@@ -32,6 +32,7 @@ TRANSLATIONS = {
         "SLASH_COMMAND": "a slash command",
         "EDITED": "(edited)",
         "POWERED_BY": "Powered by",
+        "GENERATED_WITH": "Generated with v{version}",
     },
     "fr": {
         "TRANSCRIPT_OF_CHANNEL": "Transcript du salon",
@@ -66,6 +67,7 @@ TRANSLATIONS = {
         "SLASH_COMMAND": "une commande slash",
         "EDITED": "(modifié)",
         "POWERED_BY": "Propulsé par",
+        "GENERATED_WITH": "Généré avec la v{version}",
     },
     "es": {
         "TRANSCRIPT_OF_CHANNEL": "Transcripción del canal",
@@ -100,5 +102,6 @@ TRANSLATIONS = {
         "SLASH_COMMAND": "un comando de barra",
         "EDITED": "(editado)",
         "POWERED_BY": "Impulsado por",
+        "GENERATED_WITH": "Generado con la v{version}",
     },
 }

--- a/examples/test_render.html
+++ b/examples/test_render.html
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width" />
     <meta name="title" content="Serveur de Démonstration - général">
     <meta name="description"
-        content="Transcript du salon général (987654321) de Serveur de Démonstration (123456789) avec 28 messages. Ce transcript a été généré le 3 August 2026 at 04:20:41 PM (UTC).">
+        content="Transcript du salon général (987654321) de Serveur de Démonstration (123456789) avec 28 messages. Ce transcript a été généré le 8 August 2026 at 05:10:38 PM (UTC).">
 
     <link rel="icon" type="image/svg+xml" href="https://discord-transcript.xouxou-hosting.fr/assets/img/clair/logo.svg">
 
@@ -15,13 +15,13 @@
     <meta property="og:type" content="website" />
     <meta property="og:title" content="Serveur de Démonstration - général" />
     <meta property="og:description"
-        content="Transcript du salon général (987654321) de Serveur de Démonstration (123456789) avec 28 messages. Ce transcript a été généré le 3 August 2026 at 04:20:41 PM (UTC)." />
+        content="Transcript du salon général (987654321) de Serveur de Démonstration (123456789) avec 28 messages. Ce transcript a été généré le 8 August 2026 at 05:10:38 PM (UTC)." />
 
     <!-- Twitter -->
     <meta name="twitter:card" content="summary" />
     <meta name='twitter:title' content="Serveur de Démonstration - général" />
     <meta name='twitter:description'
-        content="Transcript du salon général (987654321) de Serveur de Démonstration (123456789) avec 28 messages. Ce transcript a été généré le 3 August 2026 at 04:20:41 PM (UTC)." />
+        content="Transcript du salon général (987654321) de Serveur de Démonstration (123456789) avec 28 messages. Ce transcript a été généré le 8 August 2026 at 05:10:38 PM (UTC)." />
 
     <style>
         :root {
@@ -1120,7 +1120,6 @@
             padding: 4px 8px;
             border-radius: 4px;
             margin-left: auto;
-            margin-right: 16px;
             color: #949ba4;
             transition: background-color 0.2s ease, color 0.2s ease;
         }
@@ -1135,11 +1134,6 @@
             margin-right: 6px;
             width: 20px;
             height: 20px;
-        }
-
-        .panel__logo {
-            width: 24px;
-            height: 24px;
         }
 
         .summary-popout.visible {
@@ -1945,11 +1939,6 @@
             </svg>
             <span>Informations</span>
         </div>
-
-        <a href="https://discord-transcript.xouxou-hosting.fr/index" target="_blank" rel="noopener">
-            <img class="panel__logo" src="https://discord-transcript.xouxou-hosting.fr/assets/img/clair/logo.svg"
-                alt="DiscordTranscript" />
-        </a>
     </div>
 
     <div class="main">
@@ -1987,7 +1976,7 @@
                 <div class="chatlog__header">
                     <span class="chatlog__author-name chatlog__author-name--colored" title="Alice 🧪#1378" data-user-id="1" data-user-color="#FFFFFF">Alice <img class="emoji emoji--small" src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@latest/assets/72x72/1f9ea.png" alt="🧪" title="Test Tube" aria-label="Emoji: Test Tube"></span>
                     
-                    <span class="chatlog__timestamp" data-timestamp="Monday,  3 August 2026 03:21 PM">03-08-2026 03:21 PM</span>
+                    <span class="chatlog__timestamp" data-timestamp="Saturday,  8 August 2026 06:11 PM">08-08-2026 06:11 PM</span>
                 </div>
 
                 <div class="chatlog__content chatlog__markdown" data-message-id="1001" id="message-1001">
@@ -2026,7 +2015,7 @@
                 <div class="chatlog__header">
                     <span class="chatlog__author-name chatlog__author-name--colored" title="Bob#8462" data-user-id="2" data-user-color="#FFFFFF">Bob</span>
                     
-                    <span class="chatlog__timestamp" data-timestamp="Monday,  3 August 2026 03:21 PM">03-08-2026 03:21 PM</span>
+                    <span class="chatlog__timestamp" data-timestamp="Saturday,  8 August 2026 06:11 PM">08-08-2026 06:11 PM</span>
                 </div>
 
                 <div class="chatlog__content chatlog__markdown" data-message-id="1002" id="message-1002">
@@ -2055,7 +2044,7 @@
                 <div class="chatlog__header">
                     <span class="chatlog__author-name chatlog__author-name--colored" title="Alice 🧪#1378" data-user-id="1" data-user-color="#FFFFFF">Alice <img class="emoji emoji--small" src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@latest/assets/72x72/1f9ea.png" alt="🧪" title="Test Tube" aria-label="Emoji: Test Tube"></span>
                     
-                    <span class="chatlog__timestamp" data-timestamp="Monday,  3 August 2026 03:25 PM">03-08-2026 03:25 PM</span>
+                    <span class="chatlog__timestamp" data-timestamp="Saturday,  8 August 2026 06:15 PM">08-08-2026 06:15 PM</span>
                 </div>
 
                 <div class="chatlog__content chatlog__markdown" data-message-id="1003" id="message-1003">
@@ -2086,7 +2075,7 @@ Et voici un emoji personnalisé : <img class="emoji emoji--small" src="https://c
                 <div class="chatlog__header">
                     <span class="chatlog__author-name chatlog__author-name--colored" title="Bob#8462" data-user-id="2" data-user-color="#FFFFFF">Bob</span>
                     
-                    <span class="chatlog__timestamp" data-timestamp="Monday,  3 August 2026 03:30 PM">03-08-2026 03:30 PM</span>
+                    <span class="chatlog__timestamp" data-timestamp="Saturday,  8 August 2026 06:20 PM">08-08-2026 06:20 PM</span>
                 </div>
 
                 <div class="chatlog__content chatlog__markdown" data-message-id="1004" id="message-1004">
@@ -2143,7 +2132,7 @@ Et voici un emoji personnalisé : <img class="emoji emoji--small" src="https://c
          height="16" viewBox="0 0 16 15.2"><path d="M7.4,11.17,4,8.62,5,7.26l2,1.53L10.64,4l1.36,1Z" fill="#ffffff"></path></svg>
     <span>APP</span>
 </span>
-                    <span class="chatlog__timestamp" data-timestamp="Monday,  3 August 2026 03:35 PM">03-08-2026 03:35 PM</span>
+                    <span class="chatlog__timestamp" data-timestamp="Saturday,  8 August 2026 06:25 PM">08-08-2026 06:25 PM</span>
                 </div>
 
                 <div class="chatlog__content chatlog__markdown" data-message-id="1005" id="message-1005">
@@ -2201,7 +2190,7 @@ Et voici un emoji personnalisé : <img class="emoji emoji--small" src="https://c
         </div>
 
         <div class="chatlog__embed-footer">
-    <img class="chatlog__embed-footer-icon" src="https://lyxios.xouxou-hosting.fr/images/white_black.png" alt="Embed footer icon" title="Embed footer icon"><span class="chatlog__embed-footer-text">Généré automatiquement • 03/08/2026 15:20</span>
+    <img class="chatlog__embed-footer-icon" src="https://lyxios.xouxou-hosting.fr/images/white_black.png" alt="Embed footer icon" title="Embed footer icon"><span class="chatlog__embed-footer-text">Généré automatiquement • 08/08/2026 18:10</span>
 </div>
 
     </div>
@@ -2230,7 +2219,7 @@ Et voici un emoji personnalisé : <img class="emoji emoji--small" src="https://c
          height="16" viewBox="0 0 16 15.2"><path d="M7.4,11.17,4,8.62,5,7.26l2,1.53L10.64,4l1.36,1Z" fill="#ffffff"></path></svg>
     <span>APP</span>
 </span>
-                    <span class="chatlog__timestamp" data-timestamp="Monday,  3 August 2026 03:40 PM">03-08-2026 03:40 PM</span>
+                    <span class="chatlog__timestamp" data-timestamp="Saturday,  8 August 2026 06:30 PM">08-08-2026 06:30 PM</span>
                 </div>
 
                 <div class="chatlog__content chatlog__markdown" data-message-id="1006" id="message-1006">
@@ -2273,7 +2262,7 @@ Et voici un emoji personnalisé : <img class="emoji emoji--small" src="https://c
          height="16" viewBox="0 0 16 15.2"><path d="M7.4,11.17,4,8.62,5,7.26l2,1.53L10.64,4l1.36,1Z" fill="#ffffff"></path></svg>
     <span>APP</span>
 </span>
-                    <span class="chatlog__timestamp" data-timestamp="Monday,  3 August 2026 03:41 PM">03-08-2026 03:41 PM</span>
+                    <span class="chatlog__timestamp" data-timestamp="Saturday,  8 August 2026 06:31 PM">08-08-2026 06:31 PM</span>
                 </div>
 
                 <div class="chatlog__content chatlog__markdown" data-message-id="1007" id="message-1007">
@@ -2340,7 +2329,7 @@ Et voici un emoji personnalisé : <img class="emoji emoji--small" src="https://c
                 <div class="chatlog__header">
                     <span class="chatlog__author-name chatlog__author-name--colored" title="Alice 🧪#1378" data-user-id="1" data-user-color="#FFFFFF">Alice <img class="emoji emoji--small" src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@latest/assets/72x72/1f9ea.png" alt="🧪" title="Test Tube" aria-label="Emoji: Test Tube"></span>
                     
-                    <span class="chatlog__timestamp" data-timestamp="Monday,  3 August 2026 03:45 PM">03-08-2026 03:45 PM</span>
+                    <span class="chatlog__timestamp" data-timestamp="Saturday,  8 August 2026 06:35 PM">08-08-2026 06:35 PM</span>
                 </div>
 
                 <div class="chatlog__content chatlog__markdown" data-message-id="1008" id="message-1008">
@@ -2381,7 +2370,7 @@ Et voici un emoji personnalisé : <img class="emoji emoji--small" src="https://c
                 <div class="chatlog__header">
                     <span class="chatlog__author-name chatlog__author-name--colored" title="Alice 🧪#1378" data-user-id="1" data-user-color="#FFFFFF">Alice <img class="emoji emoji--small" src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@latest/assets/72x72/1f9ea.png" alt="🧪" title="Test Tube" aria-label="Emoji: Test Tube"></span>
                     
-                    <span class="chatlog__timestamp" data-timestamp="Monday,  3 August 2026 03:55 PM">03-08-2026 03:55 PM</span>
+                    <span class="chatlog__timestamp" data-timestamp="Saturday,  8 August 2026 06:45 PM">08-08-2026 06:45 PM</span>
                 </div>
 
                 <div class="chatlog__content chatlog__markdown" data-message-id="1010" id="message-1010">
@@ -2422,7 +2411,7 @@ Et voici un emoji personnalisé : <img class="emoji emoji--small" src="https://c
          height="16" viewBox="0 0 16 15.2"><path d="M7.4,11.17,4,8.62,5,7.26l2,1.53L10.64,4l1.36,1Z" fill="#ffffff"></path></svg>
     <span>APP</span>
 </span>
-                    <span class="chatlog__timestamp" data-timestamp="Monday,  3 August 2026 04:00 PM">03-08-2026 04:00 PM</span>
+                    <span class="chatlog__timestamp" data-timestamp="Saturday,  8 August 2026 06:50 PM">08-08-2026 06:50 PM</span>
                 </div>
 
                 <div class="chatlog__content chatlog__markdown" data-message-id="1011" id="message-1011">
@@ -2451,11 +2440,11 @@ Et voici un emoji personnalisé : <img class="emoji emoji--small" src="https://c
                 <div class="chatlog__header">
                     <span class="chatlog__author-name chatlog__author-name--colored" title="Alice 🧪#1378" data-user-id="1" data-user-color="#FFFFFF">Alice <img class="emoji emoji--small" src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@latest/assets/72x72/1f9ea.png" alt="🧪" title="Test Tube" aria-label="Emoji: Test Tube"></span>
                     
-                    <span class="chatlog__timestamp" data-timestamp="Monday,  3 August 2026 04:05 PM">03-08-2026 04:05 PM</span>
+                    <span class="chatlog__timestamp" data-timestamp="Saturday,  8 August 2026 06:55 PM">08-08-2026 06:55 PM</span>
                 </div>
 
                 <div class="chatlog__content chatlog__markdown" data-message-id="1014" id="message-1014">
-                    <div class="chatlog__markdown-preserve">Ce message a été modifié. <span class="chatlog__reference-edited-timestamp" data-timestamp="Monday,  3 August 2026 04:06 PM">(edited)</span></div>
+                    <div class="chatlog__markdown-preserve">Ce message a été modifié. <span class="chatlog__reference-edited-timestamp" data-timestamp="Saturday,  8 August 2026 06:56 PM">(edited)</span></div>
 
                     
 
@@ -2497,7 +2486,7 @@ Et voici un emoji personnalisé : <img class="emoji emoji--small" src="https://c
                 <div class="chatlog__header">
                     <span class="chatlog__author-name chatlog__author-name--colored" title="Bob#8462" data-user-id="2" data-user-color="#FFFFFF">Bob</span>
                     
-                    <span class="chatlog__timestamp" data-timestamp="Monday,  3 August 2026 04:10 PM">03-08-2026 04:10 PM</span>
+                    <span class="chatlog__timestamp" data-timestamp="Saturday,  8 August 2026 07:00 PM">08-08-2026 07:00 PM</span>
                 </div>
 
                 <div class="chatlog__content chatlog__markdown" data-message-id="1017" id="message-1017">
@@ -2543,7 +2532,7 @@ Et voici un emoji personnalisé : <img class="emoji emoji--small" src="https://c
                 <div class="chatlog__header">
                     <span class="chatlog__author-name chatlog__author-name--colored" title="Alice 🧪#1378" data-user-id="1" data-user-color="#FFFFFF">Alice <img class="emoji emoji--small" src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@latest/assets/72x72/1f9ea.png" alt="🧪" title="Test Tube" aria-label="Emoji: Test Tube"></span>
                     
-                    <span class="chatlog__timestamp" data-timestamp="Monday,  3 August 2026 04:12 PM">03-08-2026 04:12 PM</span>
+                    <span class="chatlog__timestamp" data-timestamp="Saturday,  8 August 2026 07:02 PM">08-08-2026 07:02 PM</span>
                 </div>
 
                 <div class="chatlog__content chatlog__markdown" data-message-id="1018" id="message-1018">
@@ -2576,7 +2565,7 @@ Et voici un emoji personnalisé : <img class="emoji emoji--small" src="https://c
                 <div class="chatlog__header">
                     <span class="chatlog__author-name chatlog__author-name--colored" title="Bob#8462" data-user-id="2" data-user-color="#FFFFFF">Bob</span>
                     
-                    <span class="chatlog__timestamp" data-timestamp="Monday,  3 August 2026 04:15 PM">03-08-2026 04:15 PM</span>
+                    <span class="chatlog__timestamp" data-timestamp="Saturday,  8 August 2026 07:05 PM">08-08-2026 07:05 PM</span>
                 </div>
 
                 <div class="chatlog__content chatlog__markdown" data-message-id="1019" id="message-1019">
@@ -2605,7 +2594,7 @@ Et voici un emoji personnalisé : <img class="emoji emoji--small" src="https://c
                 <div class="chatlog__header">
                     <span class="chatlog__author-name chatlog__author-name--colored" title="Alice 🧪#1378" data-user-id="1" data-user-color="#FFFFFF">Alice <img class="emoji emoji--small" src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@latest/assets/72x72/1f9ea.png" alt="🧪" title="Test Tube" aria-label="Emoji: Test Tube"></span>
                     
-                    <span class="chatlog__timestamp" data-timestamp="Monday,  3 August 2026 04:18 PM">03-08-2026 04:18 PM</span>
+                    <span class="chatlog__timestamp" data-timestamp="Saturday,  8 August 2026 07:08 PM">08-08-2026 07:08 PM</span>
                 </div>
 
                 <div class="chatlog__content chatlog__markdown" data-message-id="1020" id="message-1020">
@@ -2642,7 +2631,7 @@ Et voici un emoji personnalisé : <img class="emoji emoji--small" src="https://c
          height="16" viewBox="0 0 16 15.2"><path d="M7.4,11.17,4,8.62,5,7.26l2,1.53L10.64,4l1.36,1Z" fill="#ffffff"></path></svg>
     <span>APP</span>
 </span>
-                    <span class="chatlog__timestamp" data-timestamp="Monday,  3 August 2026 04:19 PM">03-08-2026 04:19 PM</span>
+                    <span class="chatlog__timestamp" data-timestamp="Saturday,  8 August 2026 07:09 PM">08-08-2026 07:09 PM</span>
                 </div>
 
                 <div class="chatlog__content chatlog__markdown" data-message-id="1021" id="message-1021">
@@ -2781,7 +2770,7 @@ Gérez vos paramètres utilisateur et vos préférences directement depuis ce me
                 <div class="chatlog__header">
                     <span class="chatlog__author-name chatlog__author-name--colored" title="Alice 🧪#1378" data-user-id="1" data-user-color="#FFFFFF">Alice <img class="emoji emoji--small" src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@latest/assets/72x72/1f9ea.png" alt="🧪" title="Test Tube" aria-label="Emoji: Test Tube"></span>
                     
-                    <span class="chatlog__timestamp" data-timestamp="Monday,  3 August 2026 04:20 PM">03-08-2026 04:20 PM</span>
+                    <span class="chatlog__timestamp" data-timestamp="Saturday,  8 August 2026 07:10 PM">08-08-2026 07:10 PM</span>
                 </div>
 
                 <div class="chatlog__content chatlog__markdown" data-message-id="1022" id="message-1022">
@@ -2810,7 +2799,7 @@ Gérez vos paramètres utilisateur et vos préférences directement depuis ce me
                 <div class="chatlog__header">
                     <span class="chatlog__author-name chatlog__author-name--colored" title="Bob#8462" data-user-id="2" data-user-color="#FFFFFF">Bob</span>
                     
-                    <span class="chatlog__timestamp" data-timestamp="Monday,  3 August 2026 04:20 PM">03-08-2026 04:20 PM</span>
+                    <span class="chatlog__timestamp" data-timestamp="Saturday,  8 August 2026 07:10 PM">08-08-2026 07:10 PM</span>
                 </div>
 
                 <div class="chatlog__content chatlog__markdown" data-message-id="1009" id="message-1009">
@@ -2846,7 +2835,7 @@ Gérez vos paramètres utilisateur et vos préférences directement depuis ce me
                 <div class="chatlog__header">
                     <span class="chatlog__author-name chatlog__author-name--colored" title="Bob#8462" data-user-id="2" data-user-color="#FFFFFF">Bob</span>
                     
-                    <span class="chatlog__timestamp" data-timestamp="Monday,  3 August 2026 04:21 PM">03-08-2026 04:21 PM</span>
+                    <span class="chatlog__timestamp" data-timestamp="Saturday,  8 August 2026 07:11 PM">08-08-2026 07:11 PM</span>
                 </div>
 
                 <div class="chatlog__content chatlog__markdown" data-message-id="1023" id="message-1023">
@@ -2911,7 +2900,7 @@ Gérez vos paramètres utilisateur et vos préférences directement depuis ce me
                 <div class="chatlog__header">
                     <span class="chatlog__author-name chatlog__author-name--colored" title="Alice 🧪#1378" data-user-id="1" data-user-color="#FFFFFF">Alice <img class="emoji emoji--small" src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@latest/assets/72x72/1f9ea.png" alt="🧪" title="Test Tube" aria-label="Emoji: Test Tube"></span>
                     
-                    <span class="chatlog__timestamp" data-timestamp="Monday,  3 August 2026 04:22 PM">03-08-2026 04:22 PM</span>
+                    <span class="chatlog__timestamp" data-timestamp="Saturday,  8 August 2026 07:12 PM">08-08-2026 07:12 PM</span>
                 </div>
 
                 <div class="chatlog__content chatlog__markdown" data-message-id="1024" id="message-1024">
@@ -2948,7 +2937,7 @@ Gérez vos paramètres utilisateur et vos préférences directement depuis ce me
                 <div class="chatlog__header">
                     <span class="chatlog__author-name chatlog__author-name--colored" title="Bob#8462" data-user-id="2" data-user-color="#FFFFFF">Bob</span>
                     
-                    <span class="chatlog__timestamp" data-timestamp="Monday,  3 August 2026 04:23 PM">03-08-2026 04:23 PM</span>
+                    <span class="chatlog__timestamp" data-timestamp="Saturday,  8 August 2026 07:13 PM">08-08-2026 07:13 PM</span>
                 </div>
 
                 <div class="chatlog__content chatlog__markdown" data-message-id="1025" id="message-1025">
@@ -2995,7 +2984,7 @@ Gérez vos paramètres utilisateur et vos préférences directement depuis ce me
                 <div class="chatlog__header">
                     <span class="chatlog__author-name chatlog__author-name--colored" title="Alice 🧪#1378" data-user-id="1" data-user-color="#FFFFFF">Alice <img class="emoji emoji--small" src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@latest/assets/72x72/1f9ea.png" alt="🧪" title="Test Tube" aria-label="Emoji: Test Tube"></span>
                     
-                    <span class="chatlog__timestamp" data-timestamp="Monday,  3 August 2026 04:24 PM">03-08-2026 04:24 PM</span>
+                    <span class="chatlog__timestamp" data-timestamp="Saturday,  8 August 2026 07:14 PM">08-08-2026 07:14 PM</span>
                 </div>
 
                 <div class="chatlog__content chatlog__markdown" data-message-id="1026" id="message-1026">
@@ -3051,7 +3040,7 @@ Et du code inline <span class="pre pre-inline">print(&#x27;test&#x27;)</span>. <
          height="16" viewBox="0 0 16 15.2"><path d="M7.4,11.17,4,8.62,5,7.26l2,1.53L10.64,4l1.36,1Z" fill="#ffffff"></path></svg>
     <span>APP</span>
 </span>
-                    <span class="chatlog__timestamp" data-timestamp="Monday,  3 August 2026 04:25 PM">03-08-2026 04:25 PM</span>
+                    <span class="chatlog__timestamp" data-timestamp="Saturday,  8 August 2026 07:15 PM">08-08-2026 07:15 PM</span>
                 </div>
 
                 <div class="chatlog__content chatlog__markdown" data-message-id="1027" id="message-1027">
@@ -3114,7 +3103,7 @@ Et du code inline <span class="pre pre-inline">print(&#x27;test&#x27;)</span>. <
                 <div class="chatlog__header">
                     <span class="chatlog__author-name chatlog__author-name--colored" title="Alice 🧪#1378" data-user-id="1" data-user-color="#FFFFFF">Alice <img class="emoji emoji--small" src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@latest/assets/72x72/1f9ea.png" alt="🧪" title="Test Tube" aria-label="Emoji: Test Tube"></span>
                     
-                    <span class="chatlog__timestamp" data-timestamp="Monday,  3 August 2026 04:26 PM">03-08-2026 04:26 PM</span>
+                    <span class="chatlog__timestamp" data-timestamp="Saturday,  8 August 2026 07:16 PM">08-08-2026 07:16 PM</span>
                 </div>
 
                 <div class="chatlog__content chatlog__markdown" data-message-id="1028" id="message-1028">
@@ -3156,8 +3145,8 @@ print(&#x27;Ligne de code numéro 20&#x27;)</div> </div>
     </div>
 
     <div class="footer">
-        <span class="footer__text">Ce transcript a été généré le 3 August 2026 at 04:20:41 PM (UTC)</span>
-        <div class="footer__powered">
+        <span class="footer__text">Ce transcript a été généré le 8 August 2026 at 05:10:38 PM (UTC)</span>
+        <div class="footer__powered" data-version="Généré avec la v1.5.1.dev6+gfd5fe9c0a.d20260808">
             <span>Propulsé par</span>
             <a href="https://discord-transcript.xouxou-hosting.fr/index" class="footer__powered-link" target="_blank"
                 rel="noopener">
@@ -3190,7 +3179,7 @@ print(&#x27;Ligne de code numéro 20&#x27;)</div> </div>
             </div>
             <div class="meta__field">
                 <div class="meta__title">Date de création du salon</div>
-                <div class="meta__value">Aug 03, 2026 (04:20:38 PM)</div>
+                <div class="meta__value">Aug 08, 2026 (05:10:37 PM)</div>
             </div>
             <div class="meta__field">
                 <div class="meta__title">Nombre total de messages</div>
@@ -3216,7 +3205,7 @@ print(&#x27;Ligne de code numéro 20&#x27;)</div> </div>
         <div class="meta__divider-2"></div>
         <div class="meta__field">
             <div class="meta__title">Member Since</div>
-            <div class="meta__value"><img src="https://cdn.jsdelivr.net/gh/mahtoid/DiscordUtils@master/discord-logo.svg" alt="Discord icon"/> Aug 03, 2026 <div class="meta__divider"></div> <img src="https://cdn.discordapp.com/embed/avatars/0.png" class="meta__img-border" alt="Guild icon"/> Aug 03, 2026</div>
+            <div class="meta__value"><img src="https://cdn.jsdelivr.net/gh/mahtoid/DiscordUtils@master/discord-logo.svg" alt="Discord icon"/> Aug 08, 2026 <div class="meta__divider"></div> <img src="https://cdn.discordapp.com/embed/avatars/0.png" class="meta__img-border" alt="Guild icon"/> Aug 08, 2026</div>
         </div>
         <div class="meta__field">
             <div class="meta__title">Member ID</div>
@@ -3243,7 +3232,7 @@ print(&#x27;Ligne de code numéro 20&#x27;)</div> </div>
         <div class="meta__divider-2"></div>
         <div class="meta__field">
             <div class="meta__title">Member Since</div>
-            <div class="meta__value"><img src="https://cdn.jsdelivr.net/gh/mahtoid/DiscordUtils@master/discord-logo.svg" alt="Discord icon"/> Aug 03, 2026 <div class="meta__divider"></div> <img src="https://cdn.discordapp.com/embed/avatars/0.png" class="meta__img-border" alt="Guild icon"/> Aug 03, 2026</div>
+            <div class="meta__value"><img src="https://cdn.jsdelivr.net/gh/mahtoid/DiscordUtils@master/discord-logo.svg" alt="Discord icon"/> Aug 08, 2026 <div class="meta__divider"></div> <img src="https://cdn.discordapp.com/embed/avatars/0.png" class="meta__img-border" alt="Guild icon"/> Aug 08, 2026</div>
         </div>
         <div class="meta__field">
             <div class="meta__title">Member ID</div>
@@ -3274,7 +3263,7 @@ print(&#x27;Ligne de code numéro 20&#x27;)</div> </div>
         <div class="meta__divider-2"></div>
         <div class="meta__field">
             <div class="meta__title">Member Since</div>
-            <div class="meta__value"><img src="https://cdn.jsdelivr.net/gh/mahtoid/DiscordUtils@master/discord-logo.svg" alt="Discord icon"/> Aug 03, 2026 <div class="meta__divider"></div> <img src="https://cdn.discordapp.com/embed/avatars/0.png" class="meta__img-border" alt="Guild icon"/> Aug 03, 2026</div>
+            <div class="meta__value"><img src="https://cdn.jsdelivr.net/gh/mahtoid/DiscordUtils@master/discord-logo.svg" alt="Discord icon"/> Aug 08, 2026 <div class="meta__divider"></div> <img src="https://cdn.discordapp.com/embed/avatars/0.png" class="meta__img-border" alt="Guild icon"/> Aug 08, 2026</div>
         </div>
         <div class="meta__field">
             <div class="meta__title">Member ID</div>
@@ -3474,6 +3463,14 @@ print(&#x27;Ligne de code numéro 20&#x27;)</div> </div>
                 placement: 'top',
                 animation: 'fade',
                 content: (reference) => reference.getAttribute('data-timestamp'),
+                theme: 'disc',
+            });
+
+            // Version: Tooltip
+            tippy('.footer__powered', {
+                placement: 'top',
+                animation: 'fade',
+                content: (reference) => reference.getAttribute('data-version'),
                 theme: 'disc',
             });
 


### PR DESCRIPTION
- Fetch and display the current version of DiscordTranscript in the HTML footer.
- Add a tooltip to the "Powered by" section displaying the version.
- Update .gitignore to include `uv.lock`.
- Remove unused CSS for `.panel__logo`.
- Adjust margin for a `.footer__powered` element.
- Update example HTML to reflect a different generation timestamp.

## 📝 Description des modifications

## 🔗 Ticket / Module concerné
- Module : DiscordTranscript
- Type : [ ] Correction [ ] Nouvelle fonctionnalité [ ] Amélioration [ ] Refactorisation

## ✅ Checklist de vérification
- [ ] **1 PR = 1 Changement** : Cette PR concerne un seul sujet/module (ou des modifications directement liées).
- [ ] Les tests passent en local (`pytest`).
- [ ] Le code respecte le linter et le formatage (`ruff check .` et `ruff format .`).
- [ ] La compatibilité des versions Python (>=3.10) est préservée.
- [ ] J'ai lu et j'accepte la licence [LICENSE](../LICENSE).
